### PR TITLE
Add a way to launch with the menubar hidden & normal window

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ When this value is set to `true`, application will be launched as a normal windo
 If menu bar behavior does not work for you, please use set this value to `true` to avoid it.
 Default value is `false` on macOS or Linux, `true` on Windows because window position is broken in some version of Windows.
 
+### `menubar`
+
+When this value is set to `true`, the application will be launched with the
+menubar visible, assuming `normal_window` is also true. When set to `false`, the
+menubar will be hidden on launch. Default value is `true`.
+
 ### `zoom_factor`
 
 Font zoom factor in application. It should be positive number. For example, `0.7` means `70%` font zooming.

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ When this value is set to `true`, application will be launched as a normal windo
 If menu bar behavior does not work for you, please use set this value to `true` to avoid it.
 Default value is `false` on macOS or Linux, `true` on Windows because window position is broken in some version of Windows.
 
-### `menubar`
+### `hide_menu`
 
 When this value is set to `true`, the application will be launched with the
-menubar visible, assuming `normal_window` is also true. When set to `false`, the
-menubar will be hidden on launch. Default value is `true`.
+menubar hidden, assuming `normal_window` is also true. When set to `false`, the
+menubar will be visible on launch. Default value is `false`.
 
 ### `zoom_factor`
 

--- a/main/config.ts
+++ b/main/config.ts
@@ -13,6 +13,7 @@ export interface Config {
     hot_key: string;
     icon_color: string;
     always_on_top: boolean;
+    menubar: boolean;
     normal_window: boolean;
     zoom_factor: number;
     accounts: Account[];
@@ -27,6 +28,7 @@ function makeDefaultConfig(): Config {
         hot_key: 'CmdOrCtrl+Shift+S',
         icon_color: IsDarkMode ? 'white' : 'black',
         always_on_top: false,
+        menubar: true,
         normal_window: menubarBroken,
         zoom_factor: 0.9,
         accounts: [{

--- a/main/config.ts
+++ b/main/config.ts
@@ -13,7 +13,7 @@ export interface Config {
     hot_key: string;
     icon_color: string;
     always_on_top: boolean;
-    menubar: boolean;
+    hide_menu: boolean;
     normal_window: boolean;
     zoom_factor: number;
     accounts: Account[];
@@ -28,7 +28,7 @@ function makeDefaultConfig(): Config {
         hot_key: 'CmdOrCtrl+Shift+S',
         icon_color: IsDarkMode ? 'white' : 'black',
         always_on_top: false,
-        menubar: true,
+        hide_menu: false,
         normal_window: menubarBroken,
         zoom_factor: 0.9,
         accounts: [{

--- a/main/window.ts
+++ b/main/window.ts
@@ -105,7 +105,7 @@ function startNormalWindow(account: Account, config: Config): Promise<Window> {
             icon: APP_ICON,
             show: false,
             useContentSize: true,
-            autoHideMenuBar: false,
+            autoHideMenuBar: !config.menubar,
             webPreferences: {
                 nodeIntegration: false,
                 sandbox: true,

--- a/main/window.ts
+++ b/main/window.ts
@@ -105,7 +105,7 @@ function startNormalWindow(account: Account, config: Config): Promise<Window> {
             icon: APP_ICON,
             show: false,
             useContentSize: true,
-            autoHideMenuBar: !config.menubar,
+            autoHideMenuBar: config.hide_menu,
             webPreferences: {
                 nodeIntegration: false,
                 sandbox: true,


### PR DESCRIPTION
I prefer to launch the application with a normal window, yet, the menubar on auto-hide, because most of the time, it's just taking up space and serves no purpose. This patch introduces a `config.menubar` setting that makes this possible. Defaults to `true` to preserve the current behaviour, and is only used when `normal_window` is also used.